### PR TITLE
improve vertical "whitespace" calculation

### DIFF
--- a/src/scale.financialLinear.js
+++ b/src/scale.financialLinear.js
@@ -78,8 +78,9 @@ module.exports = function(Chart) {
 			});
 
 			// Add whitespace around bars. Axis shouldn't go exactly from min to max
-			me.min = me.min - me.min * 0.05;
-			me.max = me.max + me.max * 0.05;
+			var space = (me.max - me.min) * 0.05;
+			me.min -= space;
+			me.max += space;
 
 			// Common base implementation to handle ticks.min, ticks.max, ticks.beginAtZero
 			this.handleTickRangeOptions();


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

The whitespace calculation at

https://github.com/chartjs/chartjs-chart-financial/blob/c3f235676fb6876a52a603a1ccc4e49fe10edee8/src/scale.financialLinear.js#L80

...is unhelpful for charts that have small movements around a high value. For example, if Bitcoin has recently moved within the range 10700 to 10710, the proposed scale will be from 10165 to 11245.  This pull request replaces the whitespace size with 5% of the range, rather than of the absolute value.
