### PR TITLE
Move helpers declaration inside exports so that Chart reference is accessible

### DIFF
--- a/src/controller.financial.js
+++ b/src/controller.financial.js
@@ -1,8 +1,7 @@
 ﻿'use strict';
 
-var helpers = Chart.helpers;
-
 module.exports = function(Chart) {
+	var helpers = Chart.helpers;
 
 	Chart.defaults.financial = {
 		label: '',


### PR DESCRIPTION
Hello, I was receiving some errors because this Chart was not in scope when this line was ran. Moving it inside the export seems to fix it. Does this make sense to you guys?

Thanks for contributing.

- [X] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)
