### PR TITLE
Add missing semicolon to gulpfile.js

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -37,7 +37,7 @@ var argv = yargs
   .option('force-output', {default: false})
   .option('silent-errors', {default: false})
   .option('verbose', {default: false})
-  .argv
+  .argv;
 
 function buildTask() {
   var nonBundled = browserify('./src/index.js')


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

Missing semicolon was added to the project's gulpfile.js.