### PR TITLE
Allow borderColor to be customized through border options

### DIFF
--- a/src/controller.candlestick.js
+++ b/src/controller.candlestick.js
@@ -27,7 +27,6 @@ module.exports = function(Chart) {
 
 				// Appearance
 				color: dataset.color,
-				border: dataset.border,
 				borderColor: dataset.borderColor,
 				borderWidth: dataset.borderWidth,
 			};

--- a/src/controller.candlestick.js
+++ b/src/controller.candlestick.js
@@ -27,6 +27,7 @@ module.exports = function(Chart) {
 
 				// Appearance
 				color: dataset.color,
+				border: dataset.border,
 				borderColor: dataset.borderColor,
 				borderWidth: dataset.borderWidth,
 			};

--- a/src/element.candlestick.js
+++ b/src/element.candlestick.js
@@ -6,11 +6,6 @@ module.exports = function(Chart) {
 	var globalOpts = Chart.defaults.global;
 
 	globalOpts.elements.candlestick = Object.assign(globalOpts.elements.financial, {
-		border: {
-			up: globalOpts.elements.financial.color.up,
-			down: globalOpts.elements.financial.color.down,
-			unchanged: globalOpts.elements.financial.color.unchanged
-		},
 		borderColor: globalOpts.elements.financial.color.unchanged,
 		borderWidth: 1,
 	});
@@ -26,16 +21,26 @@ module.exports = function(Chart) {
 			var l = vm.candleLow;
 			var c = vm.candleClose;
 
+			var borderColors = vm.borderColor;
+
+			if (typeof borderColors === 'string') {
+				borderColors = {
+					up: borderColors,
+					down: borderColors,
+					unchanged: borderColors
+				};
+			}
+
 			var borderColor;
 
 			if (c < o) {
-				borderColor = helpers.getValueOrDefault(vm.border ? vm.border.up : undefined, globalOpts.elements.candlestick.border.up);
+				borderColor = helpers.getValueOrDefault(borderColors ? borderColors.up : undefined, globalOpts.elements.candlestick.color.up);
 				ctx.fillStyle = helpers.getValueOrDefault(vm.color ? vm.color.up : undefined, globalOpts.elements.candlestick.color.up);
 			} else if (c > o) {
-				borderColor = helpers.getValueOrDefault(vm.border ? vm.border.down : undefined, globalOpts.elements.candlestick.border.down);
+				borderColor = helpers.getValueOrDefault(borderColors ? borderColors.down : undefined, globalOpts.elements.candlestick.color.down);
 				ctx.fillStyle = helpers.getValueOrDefault(vm.color ? vm.color.down : undefined, globalOpts.elements.candlestick.color.down);
 			} else {
-				borderColor = helpers.getValueOrDefault(vm.border ? vm.border.unchanged : undefined, globalOpts.elements.candlestick.border.unchanged);
+				borderColor = helpers.getValueOrDefault(borderColors ? borderColors.unchanged : undefined, globalOpts.elements.candlestick.color.unchanged);
 				ctx.fillStyle = helpers.getValueOrDefault(vm.color ? vm.color.unchanged : undefined, globalOpts.elements.candlestick.color.unchanged);
 			}
 

--- a/src/element.candlestick.js
+++ b/src/element.candlestick.js
@@ -6,6 +6,11 @@ module.exports = function(Chart) {
 	var globalOpts = Chart.defaults.global;
 
 	globalOpts.elements.candlestick = Object.assign(globalOpts.elements.financial, {
+		border: {
+			up: globalOpts.elements.financial.color.up,
+			down: globalOpts.elements.financial.color.down,
+			unchanged: globalOpts.elements.financial.color.unchanged
+		},
 		borderColor: globalOpts.elements.financial.color.unchanged,
 		borderWidth: 1,
 	});
@@ -21,15 +26,21 @@ module.exports = function(Chart) {
 			var l = vm.candleLow;
 			var c = vm.candleClose;
 
-			ctx.strokeStyle = helpers.getValueOrDefault(vm.borderColor, globalOpts.elements.candlestick.borderColor);
-			ctx.lineWidth = helpers.getValueOrDefault(vm.borderWidth, globalOpts.elements.candlestick.borderWidth);
+			var borderColor;
+
 			if (c < o) {
+				borderColor = helpers.getValueOrDefault(vm.border ? vm.border.up : undefined, globalOpts.elements.candlestick.border.up);
 				ctx.fillStyle = helpers.getValueOrDefault(vm.color ? vm.color.up : undefined, globalOpts.elements.candlestick.color.up);
 			} else if (c > o) {
+				borderColor = helpers.getValueOrDefault(vm.border ? vm.border.down : undefined, globalOpts.elements.candlestick.border.down);
 				ctx.fillStyle = helpers.getValueOrDefault(vm.color ? vm.color.down : undefined, globalOpts.elements.candlestick.color.down);
 			} else {
+				borderColor = helpers.getValueOrDefault(vm.border ? vm.border.unchanged : undefined, globalOpts.elements.candlestick.border.unchanged);
 				ctx.fillStyle = helpers.getValueOrDefault(vm.color ? vm.color.unchanged : undefined, globalOpts.elements.candlestick.color.unchanged);
 			}
+
+			ctx.lineWidth = helpers.getValueOrDefault(vm.borderWidth, globalOpts.elements.candlestick.borderWidth);
+			ctx.strokeStyle = helpers.getValueOrDefault(borderColor, globalOpts.elements.candlestick.borderColor);
 
 			ctx.beginPath();
 			ctx.moveTo(x, h);


### PR DESCRIPTION
Thanks for contributing.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

Add a new `border` option to customize `borderColor` through, similar to `color`.

## Testing

Now we're able to do this:

```js
new Chart(ctx, {
  type: 'candlestick',
  data: {
    datasets: [{
      color: {
        up: 'rgba(52, 207, 51, 0.5)',
        down: 'rgba(173, 0, 44, 0.5)',
        unchanged: '#747f89',
      },
      border: {
        up: '#34CF33',
        down: '#AD002C',
        unchanged: '#747f89',
      },
      borderWidth: 1.5,
      // more options & data
    }],
  },
});
```

And _colourfully_ we got this:

![captura de pantalla 2018-05-28 a la s 23 52 56](https://user-images.githubusercontent.com/206371/40638738-975ca222-62d2-11e8-8e1e-38e6bf9977ac.png)
