### PR TITLE
Add hasValue method to elements.Financial

### DIFF
--- a/src/element.financial.js
+++ b/src/element.financial.js
@@ -2,6 +2,7 @@
 
 module.exports = function(Chart) {
 
+	var helpers = Chart.helpers;
 	var globalOpts = Chart.defaults.global;
 
 	globalOpts.elements.financial = {
@@ -103,6 +104,11 @@ module.exports = function(Chart) {
 				x: vm.x,
 				y: (vm.candleHigh + vm.candleLow) / 2
 			};
+		},
+		hasValue: function() {
+			return helpers.isNumber(this._model.x) &&
+				helpers.isNumber(this._model.candleHigh) &&
+				helpers.isNumber(this._model.candleLow);
 		}
 	});
 

--- a/src/element.financial.js
+++ b/src/element.financial.js
@@ -86,13 +86,10 @@ module.exports = function(Chart) {
 		},
 		getCenterPoint: function() {
 			var vm = this._view;
-			var x, y;
-
-			var halfWidth = vm.width / 2;
-			x = vm.x - halfWidth;
-			y = (vm.candleHigh + vm.candleLow) / 2;
-
-			return {x: x, y: y};
+			return {
+				x: vm.x,
+				y: (vm.candleHigh + vm.candleLow) / 2
+			};
 		},
 		getArea: function() {
 			var vm = this._view;
@@ -102,13 +99,16 @@ module.exports = function(Chart) {
 			var vm = this._view;
 			return {
 				x: vm.x,
-				y: (vm.candleHigh + vm.candleLow) / 2
+				y: (vm.candleOpen + vm.candleClose) / 2
 			};
 		},
 		hasValue: function() {
-			return helpers.isNumber(this._model.x) &&
-				helpers.isNumber(this._model.candleHigh) &&
-				helpers.isNumber(this._model.candleLow);
+			var model = this._model;
+			return helpers.isNumber(model.x) &&
+				helpers.isNumber(model.candleOpen) &&
+				helpers.isNumber(model.candleHigh) &&
+				helpers.isNumber(model.candleLow) &&
+				helpers.isNumber(model.candleClose);
 		}
 	});
 


### PR DESCRIPTION
## Description

When `options.tooltips.position` is set to `'average'` or not specified, the tooltip won't appear. When `options.tooltips.position` is set to `'nearest'`, the tooltip will appear but not be centered on the candle.

This happens because the default `Element.hasValue` checks `_model.x` and `_model.y`, but `elements.Financial` doesn't have `_model.y` property. This PR adds `hasValue` method to `elements.Financial`, which checks `_model.x`, `_model.candleOpen`, `_model.candleHigh`, `_model.candleLow` and `_model.candleClose`.

**Edit:** For `tooltipPosition`, `(vm.candleOpen + vm.candleClose) / 2` is used instead of `(vm.candleHigh + vm.candleLow) / 2` so that the tooltip is centered on the fat part of the bar.

## Testing

The screenshots below are examples with `options.tooltips.position = 'nearest'`

**Master: https://jsfiddle.net/nagix/ub8m5tzk/**
<img width="314" alt="screen shot 2019-02-14 at 12 26 45 am" src="https://user-images.githubusercontent.com/723188/52727087-7352b480-2fef-11e9-900e-1a65fe25e408.png">

**This PR: https://jsfiddle.net/nagix/dsx4vb6h/**
<img width="313" alt="screen shot 2019-02-14 at 12 27 16 am" src="https://user-images.githubusercontent.com/723188/52727092-76e63b80-2fef-11e9-8ad0-da85b9db0987.png">