### PR TITLE
Fix #61 Error: Cannot find module 'rollup/bin/rollup'

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -48,7 +48,7 @@ function run(bin, args, done) {
 }
 
 function rollupTask(done) {
-  run('rollup/bin/rollup', ['-c'], done);
+  run('rollup/dist/bin/rollup', ['-c'], done);
 }
 
 function copyDistFilesTask() {


### PR DESCRIPTION
Based on bin path in https://github.com/chartjs/Chart.js/blob/master/gulpfile.js

Thanks for contributing.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

Changed the path of rollup

PS: I've only just noticed that this is also failing master in Travis after the version bump commit
https://travis-ci.org/chartjs/chartjs-chart-financial/builds/591814183#L498

## Testing

Sorry I don't know yet how to test a gulp file method properly, here is a screenshot of the build working.
<img width="822" alt="Screen Shot 2019-10-09 at 00 43 57" src="https://user-images.githubusercontent.com/171730/66441278-05e80e00-ea2e-11e9-9c83-bc9706049746.png">

The error
<img width="822" alt="Screen Shot 2019-10-09 at 00 45 53" src="https://user-images.githubusercontent.com/171730/66441311-3465e900-ea2e-11e9-99ef-b3350fc6297c.png">
> gulp build

> [00:45:51] Using gulpfile ~/VirtualBox/Win10/chartjs-chart-financial/gulpfile.js
> [00:45:51] Starting 'build'...
> [00:45:51] Starting 'rollupTask'...
> [00:45:51] 'rollupTask' errored after 4.01 ms
> [00:45:51] Error: Cannot find module 'rollup/bin/rollup'
>     at Function.Module._resolveFilename (internal/modules/cjs/loader.js:613:15)
>     at Function.resolve (internal/modules/cjs/helpers.js:28:19)
>     at run (/Users/andre/VirtualBox/Win10/chartjs-chart-financial/gulpfile.js:42:21)
>     at rollupTask (/Users/andre/VirtualBox/Win10/chartjs-chart-financial/gulpfile.js:51:3)
>     at bound (domain.js:400:14)
>     at runBound (domain.js:413:12)
>     at asyncRunner (/Users/andre/VirtualBox/Win10/chartjs-chart-financial/node_modules/async-done/index.js:55:18)
>     at processTicksAndRejections (internal/process/next_tick.js:74:9)
> [00:45:51] 'build' errored after 10 ms
