### PR TITLE
Add polyfill for Luxon for example to work in IE11

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -3,6 +3,7 @@
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, initial-scale=1">
 		<title>Financial | Chart.js</title>
+		<script src="https://cdn.polyfill.io/v2/polyfill.js?features=default,String.prototype.repeat,Array.prototype.find,Array.prototype.findIndex,Math.trunc,Math.sign"></script>
 		<script src="https://cdn.jsdelivr.net/npm/luxon@1.15.0"></script>
 		<script src="https://cdn.jsdelivr.net/npm/chart.js@2.8.0"></script>
 		<script src="https://cdn.jsdelivr.net/npm/chartjs-adapter-luxon@0.1.1"></script>


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

Not sure if IE11 support is desired but this changes the examples to work with IE11.
Uses Moment.js for the examples in the docs rather than Luxon.

Related #60
## Testing

Working with IE11, ran `gulp test`, if there are any articles on how to add tests according to what you want can you please let me know?
<img width="898" alt="Screen Shot 2019-10-09 at 11 22 00" src="https://user-images.githubusercontent.com/171730/66473385-111b5800-ea87-11e9-9695-7da6b5e978cd.png">

