### PR TITLE
add metaExtensions type

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -26,6 +26,7 @@ declare module 'chart.js' {
       chartOptions: BarControllerChartOptions;
       datasetOptions: BarControllerDatasetOptions;
       defaultDataPoint: FinancialDataPoint;
+      metaExtensions: {};
       parsedDataType: FinancialParsedData;
       scales: keyof CartesianScaleTypeRegistry;
     };
@@ -33,6 +34,7 @@ declare module 'chart.js' {
       chartOptions: BarControllerChartOptions;
       datasetOptions: BarControllerDatasetOptions;
       defaultDataPoint: FinancialDataPoint;
+      metaExtensions: {};
       parsedDataType: FinancialParsedData;
       scales: keyof CartesianScaleTypeRegistry;
     }


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

Adds the recently needed `metaExtensions` type to ChartTypeRegistry, using the same convention in the base chart.js chart types.  See related issue.

Fixes #112