### PR TITLE
add candlestick dataset options types

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -21,10 +21,18 @@ declare module 'chart.js' {
     _custom?: any
   }
 
+  type CandlestickControllerDatasetOptions = BarControllerDatasetOptions & {
+    borderColor: {
+      up: string,
+      down: string,
+      unchanged: string
+    };
+  }
+
   interface ChartTypeRegistry {
     candlestick: {
       chartOptions: BarControllerChartOptions;
-      datasetOptions: BarControllerDatasetOptions;
+      datasetOptions: CandlestickControllerDatasetOptions;
       defaultDataPoint: FinancialDataPoint;
       metaExtensions: {};
       parsedDataType: FinancialParsedData;


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

Fixes #114 

Adding custom `CandlestickControllerDatasetOptions` typings to replace use of `BarControllerDatasetOptions` to allow for unique `borderColor` type:

```typescript
borderColor: {
  up: string,
  down: string,
  unchanged: string
};
```

This will allow the configuration of bar color properties in Typescript/Angular sites where typings are needed.  For example:

![image](https://user-images.githubusercontent.com/8432125/145940589-6a1580bf-e9c2-43b6-a5b3-9a22e3b6cd12.png)

```typescript
// sample usage

let candleOptions = Chart.defaults.elements["candlestick"];

// sets body color
candleOptions.color.up = 'blue';
candleOptions.color.down = 'orange';

myConfig.data = {
  datasets: [
    {
      type: 'candlestick',
      label: 'Price',
      data: price,
      borderColor: {  // set border and wicks color
        up: candleOptions.color.up,
        down: candleOptions.color.down,
        unchanged: candleOptions.color.unchanged
      },
      yAxisID: 'yAxis'
    }
  ]
};
```

## Additional comments

I'm not a JS expert, so please treat this as a suggestion.  There may be a better way to handle it.  This approach seems to be a bit of a hack.  I have two other suggestions here:

1. Make this the default so you'd only need to provide `borderColor` if you wanted a consistently colored border.

   ```typescript
    borderColor: {
      up: candleOptions.color.up,
      down: candleOptions.color.down,
      unchanged: candleOptions.color.unchanged
    }
   ```

2. Allow use of `backgroundColor` in a similar up/down/unchanged format.  Overriding `Chart.defaults.elements["candlestick"]` as shown in my example (above) is less intuitive.

> @santam85 this replaces #115 